### PR TITLE
Remove C# warnings in latest Unity versions

### DIFF
--- a/Assets/Kino/Glitch/AnalogGlitch.cs
+++ b/Assets/Kino/Glitch/AnalogGlitch.cs
@@ -75,7 +75,7 @@ namespace Kino
 
         #region Private Properties
 
-        [SerializeField] Shader _shader;
+        [SerializeField] Shader _shader = null;
 
         Material _material;
 

--- a/Assets/Kino/Glitch/DigitalGlitch.cs
+++ b/Assets/Kino/Glitch/DigitalGlitch.cs
@@ -43,7 +43,7 @@ namespace Kino
 
         #region Private Properties
 
-        [SerializeField] Shader _shader;
+        [SerializeField] Shader _shader = null;
 
         Material _material;
         Texture2D _noiseTexture;


### PR DESCRIPTION
Hello! Thanks for your work!

I've found unwanted warnings, which presented in the latest Unity version (2020), can you please merge that pull request and maybe regenerate the unity package also? (the project failed to upgrade, but the package version works nicely)

You can read the related discussion here - https://forum.unity.com/threads/warning-cs0649-not-suppressed-properly-when-field-is-marked-as-serializefield.556009/